### PR TITLE
Feature/formfield placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # kursausschreibung 3.1.0
-=======
 [![Build Status](https://travis-ci.org/erz-mba-fbi/kursausschreibung.svg?branch=master)](https://travis-ci.org/erz-mba-fbi/kursausschreibung)
 
 ## Prerequisites

--- a/app/framework/date-helpers.js
+++ b/app/framework/date-helpers.js
@@ -81,6 +81,19 @@ export function eventStarted(event) {
   return parse(event.DateFrom).getTime() >= now.getTime();
 }
 
+/**
+ * return true when the DateTo earlier or equal
+ * to current date is. If DateTo null then current date
+ * @param {object} event event to check
+ */
+export function eventEnded(event) {
+  let now = new Date();
+  if (event.DateTo === null) {
+    return now.getTime() === now.getTime();
+  } 
+  return parse(event.DateTo).getTime() <= now.getTime();
+}
+
 
 /**
  * combine a date and a time to a single date object

--- a/app/framework/store.js
+++ b/app/framework/store.js
@@ -5,7 +5,7 @@ import $ from 'jquery';
 import { getEvents, getEvent, getLessons, getEventLocations, getEventTexts } from './api';
 import { isGreen, isChartreuse, isYellow, isRed } from './status';
 import ObjectProxy from '@ember/object/proxy';
-import { formatDate, combineDate, isInSubscriptionRange, removeMinutes, eventStarted } from './date-helpers';
+import { formatDate, combineDate, isInSubscriptionRange, removeMinutes, eventStarted, eventEnded } from './date-helpers';
 import { all } from 'rsvp';
 import settings from './settings';
 import { getLanguage, getString } from './translate';
@@ -217,7 +217,14 @@ function filterEvents(events, language) {
       (event.LanguageOfInstruction === 'Französisch' && language === 'en-US'));
   }
 
-  events = events.filter(event => eventStarted(event));
+  if (settings.showStartedEvents) {
+    // Filter out events which have not ended yet
+    events = events.filter(event => !eventEnded(event));
+  } else {
+    // Default behaviour, filter out events which have started
+    events = events.filter(event => eventStarted(event));
+  }
+
   return events;
 }
 

--- a/app/routes/list/category/event/subscribe.js
+++ b/app/routes/list/category/event/subscribe.js
@@ -65,6 +65,13 @@ function addTranslations(fields) {
   fields.forEach(detail => {
     if (detail.label === undefined)
       detail.label = getString('form' + detail.id);
+
+    if (detail.options !== undefined) {
+      if( detail.options.showPlaceholder === true ) {
+        let key = detail.options.placeholderKey ? detail.options.placeholderKey : 'form' + detail.id + 'Placeholder';
+        detail.placeholder = getString(key);
+      }
+    }
   });
 
   return fields;

--- a/app/templates/components/input/input-number.hbs
+++ b/app/templates/components/input/input-number.hbs
@@ -1,2 +1,2 @@
 <input class="uk-input" type="number" name={{field.id}} required={{field.options.required}} autocomplete={{field.options.autocomplete}}
-  disabled={{field.options.disabled}}>
+  disabled={{field.options.disabled}} placeholder="{{field.placeholder}}">

--- a/app/templates/components/input/input-string.hbs
+++ b/app/templates/components/input/input-string.hbs
@@ -1,2 +1,2 @@
 <input class="uk-input" type="text" name={{field.id}} required={{field.options.required}} autocomplete={{field.options.autocomplete}}
-  disabled={{field.options.disabled}} list={{field.options.datalist}}>
+  disabled={{field.options.disabled}} list={{field.options.datalist}} placeholder="{{field.placeholder}}">

--- a/public/settings.js.example
+++ b/public/settings.js.example
@@ -91,7 +91,7 @@ window.kursausschreibung.settings = {
         {
           "id": "LastName",
           "dataType": "string",
-          "options": { "required": true, "autocomplete": "family-name" }
+          "options": { "required": true, "autocomplete": "family-name", "showPlaceholder": true, "placeholderKey": "formLastName" }
         },
         {
           "id": "AddressLine1",

--- a/public/settings.js.example
+++ b/public/settings.js.example
@@ -9,6 +9,9 @@ window.kursausschreibung.settings = {
     "statusIds": null,
   },
 
+  // show events which have already started, but not yet ended
+  "showStartedEvents": false,
+
   // items per page on the event-list (required)
   "itemsPerPage": 10,
 


### PR DESCRIPTION
I have added the possibility of displaying a placeholder in the input fields.

It can be fully configured from the settings.js file.

There are two options which can be set under the field's options:

`showPlaceholder`: true Shows a placeholder in the input field
`placeholderKey`: "string" Set to a custom key which is in your translation file. If not specified, the key from the input-field + "Placeholder" will be used

I am not completely sure about the latter one, whether it would be better to default to the same as the input label instead of adding Placeholder?

The feature is only added to input-types string and number, since other types either had already a placeholder or do not need one.

(Branch created from master, since develop is still broken for me)