### PR TITLE
Bump Version to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kursausschreibung",
-  "version": "3.1.0",
+  "version": "3.3.0",
   "private": true,
   "description": "Evento JS Module for online course announcement",
   "license": "MIT",


### PR DESCRIPTION
Die Version im package.json steht immer noch auf 3.1.0.

Die sollte eigentlich den aktuellsten Release 3.3.0 repräsentieren, oder?