### PR TITLE
eventEnded should return false if no enddate

### DIFF
--- a/app/framework/date-helpers.js
+++ b/app/framework/date-helpers.js
@@ -86,7 +86,7 @@ export function eventStarted(event) {
 export function eventEnded(event) {
   let now = new Date();
   if (event.DateTo === null) {
-    return true;
+    return false;
   }
   return parseISO(event.DateTo).getTime() <= now.getTime();
 }


### PR DESCRIPTION
Die Funktion eventEnded hat den Fall, wenn kein Enddatum im Event vorhanden ist, gegensätzlich zur eventStarted Methode behandelt.
Mit diesem Fix werden Events ohne Enddatum als "noch laufend" betrachtet, analog zu eventStarted, welches Events ohne Startdatum als bereits gestartet zurückgibt.