### PR TITLE
Handle plain string localStorage values to be able to JSON-parse them

### DIFF
--- a/app/framework/storage.js
+++ b/app/framework/storage.js
@@ -16,6 +16,10 @@ function setItem(key, value) {
 function getItem(key) {
   let item = localStorage.getItem(key);
 
+  if (item && !item.includes('"')) {
+    item = `"${item}"`;
+  }
+
   return item !== undefined ? JSON.parse(item) : null;
 }
 


### PR DESCRIPTION
@schefbi Das ist ein Fix, der das Handling von Strings welche keine JSON Daten sind innerhalb der Kursausschreibungs-App löst, anstatt den localStorage Wert zu verändern, was grundsätzlich keine gute Idee ist und Portal-seitig zu Problemen führt.

Habe gleichzeitig die Änderung im (beim Portal) eingecheckten, minifizierten Code gemacht.